### PR TITLE
update to ubuntu 22.04

### DIFF
--- a/.github/workflows/create-and-tag-release.yml
+++ b/.github/workflows/create-and-tag-release.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   build_release:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/elixir-build-and-publish.yml
+++ b/.github/workflows/elixir-build-and-publish.yml
@@ -27,7 +27,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v1


### PR DESCRIPTION
As ubuntu18 is almost deprecated (starting April 1 I believe) we need to update these two ubuntu 22.

## Concerns
I know that deployer uses this but I'm not sure of any other repos that might. Not sure how we adequately test this change, maybe @tonyrud  has ideas?